### PR TITLE
Fix edit_trip string resource

### DIFF
--- a/feature/trips/src/main/res/values/strings.xml
+++ b/feature/trips/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="add_trip">Add a trip</string>
     <string name="image_description">%s trip\'s image</string>
     <string name="delete_question">Are you sure you want to delete this trip?</string>
-    <string name="edit_trip">"Edit Trip"</string>
+    <string name="edit_trip">Edit Trip</string>
     <string name="add_new_trip">Add new trip</string>
     <string name="no_trips_planned_yet">No trips planned… yet!</string>
     <string name="going">Going</string>


### PR DESCRIPTION
## Summary
- remove stray quotes in edit_trip string

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687302382dc8832abee852db0a3f623e